### PR TITLE
Add tick symbol fallback for windows consoles with limited fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Thanks to everybody who has helped. So far this includes:
 
 ## Tests
 
-Make sure you `npm install -g mocha`, then `npm tests` this repo.
+Make sure you `npm install -g mocha`, then `npm test` this repo.
 
 ### Possible domains for this project:
 

--- a/index.js
+++ b/index.js
@@ -52,6 +52,13 @@ if (program.username && program.password) {
 }
 
 function listReporter(err, report) {
+
+	var successSymbol = '✓'
+
+	if (process.platform === 'win32') {
+		successSymbol = '√';
+	}
+
 	if (err) {
 		return console.error('Error: ', err.message);
 	}
@@ -59,7 +66,7 @@ function listReporter(err, report) {
 	console.log('');
 	console.log('# Features'.magenta);
 	report.passes.forEach(function(pass) {
-		console.log('✓'.green, pass.message);
+		console.log(successSymbol.green, pass.message);
 	});
 	console.log('');
 	console.log('# Suggestions'.magenta);


### PR DESCRIPTION
The green unicode ticks in the 'Features' sections are no in the console font in windows, so it shows a bunch of '□', which is a bit confusing.

I've followed what mocha does - https://github.com/mochajs/mocha/pull/641/files 