### PR TITLE
Change call to get tree with a depth

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -18,7 +18,8 @@
 
 	function forkability(options, callback) {
 		options = merge({
-			languages: []
+			languages: [],
+			fileDepth: 2
 		}, options);
 		var passes = [];
 		var failures = [];
@@ -83,7 +84,7 @@
 				lintOptions = merge(lintOptions, {
 					containsCode: repoLanguages.length > 0
 				});
-				var url = 'https://api.github.com/repos/' + username + '/' + repo + '/git/trees/' + firstCommitSha;
+				var url = 'https://api.github.com/repos/' + username + '/' + repo + '/git/trees/' + firstCommitSha + '?recursive=' + options.fileDepth;
 				return get(url);
 			})
 			.then(function(response) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "*.js"
   },
   "scripts": {
-    "test": "mocha spec/*.test.js spec/**/*.test.js --reporter spec",
+    "test": "mocha spec/*.test.js spec/**/*.test.js --reporter spec -c -G",
     "watch": "npm-watch"
   },
   "author": "Dan Hough <dan@danhough.com>",

--- a/spec/helper.mockResponses.js
+++ b/spec/helper.mockResponses.js
@@ -4,8 +4,9 @@ beforeEach(function () {
 	nock.cleanAll();
 });
 
-function mockResponses(responses) {
+function mockResponses(responses, recursiveParam) {
 	responses = responses || {};
+	recursiveParam = recursiveParam || 2;
 
 	nock('https://api.github.com', {
 		reqHeaders: responses.firstCommitTreeRequestHeaders || {
@@ -18,7 +19,7 @@ function mockResponses(responses) {
 		}]);
 
 	nock('https://api.github.com')
-		.get('/repos/thatoneguy/thatonerepo/git/trees/fakeshalol')
+		.get('/repos/thatoneguy/thatonerepo/git/trees/fakeshalol?recursive=' + recursiveParam)
 		.reply(responses.firstCommitTreeStatus || 200, responses.firstCommitTreeBody || {
 			tree: [{
 				path: 'contributing.md'

--- a/spec/lintDeepFiles.js
+++ b/spec/lintDeepFiles.js
@@ -1,0 +1,53 @@
+var forkability = require('..');
+var should = require('should');
+var mockResponses = require('./helper.mockResponses.js');
+
+describe('files at a depth', function() {
+
+	describe('custom depth', function(){
+
+		it('should return the presence of a requirement that is filled after the default depth -but within the range of the custom depth', function(done){
+			mockResponses({
+				firstCommitTreeBody: {
+					tree:[{
+						path: 'source',
+						type: 'tree'
+					}, {
+						path: 'source/main',
+						type: 'tree',
+						sha: 'secondSha',
+						url: 'https://api.github.com/repos/thatoneguy/thatonerepo/git/trees/secondSha'
+					}, {
+						path: 'source/main/second',
+						type: 'tree',
+						sha: 'thirdSha',
+						url: 'https://api.github.com/repos/thatoneguy/thatonerepo/git/trees/thirdSha'
+					}, {
+						path: 'source/main/second/third/',
+						type: 'tree',
+						sha: 'fourthSha',
+						url: 'https://api.github.com/repos/thatoneguy/thatonerepo/git/trees/fourthSha'
+					}, {
+						path: 'source/main/second/third/tests',
+						type: 'tree'
+					}]
+				}
+			}, 4);
+
+			forkability({
+				user: 'thatoneguy',
+				repository: 'thatonerepo',
+				fileDepth: 4
+			},
+			function(err, report){
+				should(err).eql(null);
+				report.passes.should.containEql({ message : 'Test suite' });
+				report.failures.should.containEql({ message : 'Contributing document' });
+				report.failures.should.containEql({ message : 'Readme document' });
+				report.failures.should.containEql({ message : 'Licence document' });
+				report.failures.should.containEql({ message : 'Changelog document' });
+				done();
+			});
+		});
+	});
+});


### PR DESCRIPTION
It seems that is all that is needed. See [here](https://developer.github.com/v3/git/trees/#get-a-tree-recursively).
The response flattens everything into one array, so none of the other code needs to be touched (and tests stay the same for the most part)