### PR TITLE
Detect "history" files as a changelog

### DIFF
--- a/lib/lintFiles.js
+++ b/lib/lintFiles.js
@@ -11,7 +11,7 @@ module.exports = function(tree, options) {
 		'Contributing document': /^contributing/i,
 		'Readme document': /^readme/i,
 		'License document': /^(licen[cs]e|copying)/i,
-		'Changelog document': /^change(s|log)/i,
+		'Changelog document': /^(change(s|log)|history)/i,
 		'.gitignore file': /.gitignore/,
 		'Test suite': {
 			type: 'tree',

--- a/spec/lintFiles.test.js
+++ b/spec/lintFiles.test.js
@@ -253,6 +253,18 @@ describe('lintFiles', function () {
 		report.passes.should.containEql({ message : 'Changelog document' });
 	});
 
+	it('should return presence of a changelog called history with a markdown extension', function () {
+		var tree = [
+			{
+				path:'history.md'
+			}
+		];
+
+		var report = lintFiles(tree);
+
+		report.passes.should.containEql({ message : 'Changelog document' });
+	});
+
 	it('should return presence of a changelog called changelog with no extension', function () {
 		var tree = [
 			{


### PR DESCRIPTION
Quite a few open source projects use a file named "HISTORY" as a changelog. It's also confirmed by [this Wikipedia page](https://en.wikipedia.org/wiki/Changelog) on the subject.

This PR updates the file linter to also detect history files.