### PR TITLE
Install Mocha as a development dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Thanks to everybody who has helped. So far this includes:
 
 ## Tests
 
-Make sure you `npm install -g mocha`, then `npm test` this repo.
+Run `npm test` in this repo.
 
 ### Possible domains for this project:
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "*.js"
   },
   "scripts": {
-    "test": "mocha spec/*.test.js spec/**/*.test.js --reporter spec -c -G",
+    "test": "./node_modules/.bin/mocha spec/*.test.js spec/**/*.test.js --reporter spec -c -G",
     "watch": "npm-watch"
   },
   "author": "Dan Hough <dan@danhough.com>",
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "interfake": "^1.9.2",
+    "mocha": "^2.3.4",
     "nock": "^0.47.0",
     "should": "^4.0.4",
     "npm-watch": "0.0.0"


### PR DESCRIPTION
I don't know if you're adverse to this, but it means one less step for new contributors if you install Mocha as a development dependency. It caught me out for just a second :)