### PR TITLE
lib/lintFiles.js: Accept news as a changelog file

### DIFF
--- a/lib/lintFiles.js
+++ b/lib/lintFiles.js
@@ -11,7 +11,7 @@ module.exports = function(tree, options) {
 		'Contributing document': /^contributing/i,
 		'Readme document': /^readme/i,
 		'License document': /^(licen[cs]e|copying)/i,
-		'Changelog document': /^(change(s|log)|history)/i,
+		'Changelog document': /^(change(s|log)|history|news)/i,
 		'.gitignore file': /.gitignore/,
 		'Test suite': {
 			type: 'tree',

--- a/spec/lintFiles.test.js
+++ b/spec/lintFiles.test.js
@@ -278,6 +278,30 @@ describe('lintFiles', function () {
 		report.failures.should.not.containEql({ message : 'Changelog document' });
 	});
 
+  it('should return presence of a changelog called news with no extensions', function () {
+    var tree = [
+      {
+        path:'news'
+      }
+    ];
+
+    var report = lintFiles(tree);
+
+    report.passes.should.containEql({ message : 'Changelog document' });
+  });
+
+  it('should return presence of an upper-case changelog called news with a markdown extension', function () {
+    var tree = [
+      {
+        path:'NEWS.md'
+      }
+    ];
+
+    var report = lintFiles(tree);
+
+    report.passes.should.containEql({ message : 'Changelog document' });
+  });
+
 	it('should return presence of a .gitignore file called .gitignore', function () {
 		var tree = [
 			{


### PR DESCRIPTION
There are a number of projects that ship with a NEWS file, a summary of changes between release versions, and do not have a ChangeLog file, per se. The rationale for including NEWS as an acceptable change log is that it is shorter and easier to follow than a full changelog, thus, useful for both users and contributors.
