### PR TITLE
Added a default make task: deps->test->compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ node_modules
 typings/
 .settings/
 tsd.d.ts
+
+# vim files
+*.swp

--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ Thanks to the generosity of [shields.io](https://shields.io) there is in fact a 
 
 Clone the repo using `git clone git@github.com:basicallydan/forkability.git` or HTTPS if you'd prefer. Once it's downloaded, you can use `make deps` to install dependencies. Use `make help` to see other `makefile` commands available such as `test`, `serve` and `compile` which are all useful for developing and testing new features.
 
+The default `make` task will do the job of resolving dependencies, then testing the code, then compiling the code for the browser.
+
 For more info on contributing to Forkability including guidelines, see [contributing.md](https://github.com/basicallydan/forkability/blob/master/contributing.md).
 
 A key consideration when making contributions is to consider what makes a project forkable; there are many ways to look at a project and thus probably many opinions.

--- a/makefile
+++ b/makefile
@@ -2,10 +2,13 @@ VERSION ?= edge
 
 CFLAGS = -c -g -D $(VERSION)
 
+default: deps test compile
+
 help:
+	@echo "  [default]   installs dependencies, tests and compiles for the browser"
 	@echo "  deps        install dependencies"
 	@echo "  test        runs tests"
-	@echo "  compile     sets up your js files for production"
+	@echo "  compile     builds the JS files for use in the browser"
 	@echo "  serve       run the webserver"
 	@echo "  shrinkwrap  resets the shrinkwrap.json file"
 

--- a/makefile
+++ b/makefile
@@ -18,10 +18,13 @@ deps:
 test:
 	npm test
 
-compile: deps
+compile:
 	./node_modules/.bin/browserify lib/app.js | ./node_modules/.bin/uglifyjs -c > dist/forkability.$(VERSION).min.js
 	./node_modules/.bin/browserify lib/app.js > dist/forkability.$(VERSION).js
+
 serve:
 	ruby -rwebrick -e'WEBrick::HTTPServer.new(:Port => 3000, :DocumentRoot => Dir.pwd).start'
+
 shrinkwrap:
 	rm -rf node_modules/ npm-shrinkwrap.json && npm install && npm shrinkwrap
+


### PR DESCRIPTION
This came out of a conversation in #88. Although we agreed that simply running
deps and then compile would do, I felt that putting `tests` in there would work
too.

The reason for having this is in order to make it as easy as possible for people
to start working on the code in the browser, and to make sure it's all working
in the process.