### PR TITLE
Make web app language input case-insensitive

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -52,12 +52,13 @@
 		};
 
 		for (var i = options.languages.length - 1; i >= 0; i--) {
-			if (languages[options.languages[i]]) {
-				lintOptions.files = merge(lintOptions.files, languages[options.languages[i]].files);
-				lintOptions.ignore = merge(lintOptions.ignore, languages[options.languages[i]].ignore);
-				supportedLanguages.push(options.languages[i]);
+			var currentLanguage = options.languages[i].toLowerCase();
+			if (languages[currentLanguage]) {
+				lintOptions.files = merge(lintOptions.files, languages[currentLanguage].files);
+				lintOptions.ignore = merge(lintOptions.ignore, languages[currentLanguage].ignore);
+				supportedLanguages.push(currentLanguage);
 			} else {
-				console.warn('Sorry, Forkability doesn\'t support the language', options.languages[i] + '. If you\'re keen you can open a pull request at https://github.com/basicallydan/forkability/issues');
+				console.warn('Sorry, Forkability doesn\'t support the language', currentLanguage + '. If you\'re keen you can open a pull request at https://github.com/basicallydan/forkability/issues');
 			}
 		}
 

--- a/spec/app.test.js
+++ b/spec/app.test.js
@@ -440,4 +440,55 @@ describe('forkability', function () {
 				done();
 			});
 	});
+
+	it('should allow uppercase spellings of languages to be used for linting', function (done) {
+		mockResponses({
+			tagsBody: ['tag1'],
+			firstCommitTreeBody: {
+				tree: [{
+					path: 'contributing.md'
+				}, {
+						path: 'readme.md'
+					}, {
+						path: 'licence.md'
+					}, {
+						path: 'codeofconduct.md'
+					}, {
+						path: 'changelog.md'
+					}, {
+						path: '.gitignore'
+					}, {
+						path: 'spec',
+						type: 'tree'
+					}, {
+						path: 'setup.py'
+					}, {
+						path: 'requirements.txt'
+					}, {
+						path: 'docs',
+						type: 'tree'
+					}, {
+						path: 'tests',
+						type: 'tree'
+					},{
+					path:'package.json'
+				}]
+			}
+		});
+
+		forkability({
+			user: 'thatoneguy',
+			repository: 'thatonerepo',
+			languages: ['Python', 'Nodejs']
+		},
+			function (err, report) {
+				should(err).eql(null);
+				console.log(report);
+				
+				report.passes.should.have.a.lengthOf(14);
+				report.failures.should.have.a.lengthOf(0);
+				report.badge.type.should.equal(forkability.badgeTypes.ok);
+				done();
+			});
+	});
 });


### PR DESCRIPTION
This changes the way the web app interprets user entered languages, so that languages are not required to be inputted using a specific case. It also adds a test case for case insensitivity.

This still has a few issues that need to be adressed, and its commits should be squashed before merging. Should eventually fix #82.